### PR TITLE
Added cuda12x as optional dependency in the pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,8 @@ In the current version, with the introduction of the **Tyger capability**, the A
 - The code will continue to run using CPU paths (or Tyger paths) instead
 
 You may safely skip CuPy/CUDA installation unless you explicitly plan to use the legacy ART postprocessing toolbox.
+If you install MaRGE from `pyproject.toml`, GPU support can be requested explicitly with:
+
+```bash
+pip install .[gpu]
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "resources",
     "requests >= 2.25.1",
     "numpy",
     "matplotlib",
@@ -41,6 +40,11 @@ dependencies = [
     "reportlab",
     "pillow",
     "mrd-python >= 2.0.0",
+]
+
+[project.optional-dependencies]
+gpu = [
+    "cupy-cuda12x",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ bm4d
 phantominator
 pyserial
 ismrmrd
-cupy-cuda12x
 pypulseq==1.4.2
 marga_pulseq
 scikit-learn


### PR DESCRIPTION
If running on systems without direct coda support - the requirements need manual intervention. To avoid this an optional dependency was added to the pyproject can can easily installed. using [gpu] postfix as stated in the README