### PR TITLE
Added __main__.py to make marge callable as module

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: MARGE",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "marge"
+        }
+    ]
+}

--- a/marge/__main__.py
+++ b/marge/__main__.py
@@ -1,0 +1,9 @@
+from marge.main import MaRGE
+
+
+def main() -> None:
+    MaRGE()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added a __main__.py and an example vs code launch file to be able to debug Marges as module easier - it makes marge executable as module (python -m marge) as well