### PR TITLE
Added a multios bash scrip execution for win mac linux with windows u…

### DIFF
--- a/marge/configs/hw_config.py
+++ b/marge/configs/hw_config.py
@@ -38,8 +38,7 @@ dfov = [0.0, 0.0, 0.0] # mm
 rotations = []
 dfovs = []
 fovs = []
-
-bash_path = "gnome-terminal"
+# bash_override = "/bin/bash" # Example of bash override. Uncomment and set to your desired launcher if needed.
 rp_ip_address = "192.168.1.101"
 rp_ip_list = []
 rp_version = "rp-122"

--- a/marge/controller/controller_session.py
+++ b/marge/controller/controller_session.py
@@ -16,6 +16,7 @@ import qdarkstyle
 import marge.configs.hw_config as hw
 from .controller_main import MainController
 from marge.ui.window_session import SessionWindow
+from marge.utils.bash_execution import BashExecution
 
 
 from marge.controller.controller_console import ConsoleController
@@ -336,7 +337,7 @@ class SessionController(SessionWindow):
             if not self.main_gui.demo:
                 # Close server
                 try:
-                    subprocess.run([hw.bash_path, "--", "./communicateRP.sh", hw.rp_ip_address, "killall marcos_server"])
+                    BashExecution("./communicateRP.sh", hw.rp_ip_address, "killall marcos_server")
                 except Exception as e:
                     print("ERROR: Server connection not found! Please verify if the blue LED is illuminated on the Red Pitaya.")
                     print(str(e))
@@ -383,8 +384,7 @@ class SessionController(SessionWindow):
             if not self.main_gui.demo:
                 # Close server
                 try:
-                    subprocess.run(
-                        [hw.bash_path, "--", "./communicateRP.sh", hw.rp_ip_address, "killall marcos_server"])
+                    BashExecution("./communicateRP.sh", hw.rp_ip_address, "killall marcos_server")
                 except Exception as e:
                     print("ERROR: Server connection not found! Please verify if the blue LED is illuminated on the Red Pitaya.")
                     print(str(e))

--- a/marge/controller/controller_toolbar_marcos.py
+++ b/marge/controller/controller_toolbar_marcos.py
@@ -17,6 +17,7 @@ import marge.marcos.marcos_client.experiment as ex
 import marge.configs.hw_config as hw
 import marge.marge_tyger.tyger_config as tyger
 from marge.autotuning import autotuning
+from marge.utils.bash_execution import BashExecution
 
 
 class MarcosController(MarcosToolBar):
@@ -112,8 +113,8 @@ class MarcosController(MarcosToolBar):
                     result = subprocess.run(['ping', '-c', '1', ip], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=timeout)
                 elif platform.system() == 'Windows':
                     result = subprocess.run(['ping', '-n', '1', ip], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=timeout)
-                else:
-                    continue
+                elif platform.system() == 'Darwin':
+                    result = subprocess.run(['ping', '-c', '1', ip], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=timeout)
 
                 if result.returncode == 0:
                     print(f"Checking ip {ip}...")
@@ -123,6 +124,7 @@ class MarcosController(MarcosToolBar):
                         ip_addresses.append(ip)
                     else:
                         print(f"WARNING: No SDRLab found at ip {ip}")
+                        print(f"Make sure that a manual connection to ssh root@{ip} is possible and passwordless login is set up and all keys are verified.")
             except:
                 print(f"WARNING: No SDRLab found at ip {ip}")
                 continue
@@ -148,15 +150,15 @@ class MarcosController(MarcosToolBar):
     def controlMarcosServer(self):
         if not self.main.demo:
             if not self.action_server.isChecked():
-                subprocess.run([hw.bash_path, "--", "./communicateRP.sh", hw.rp_ip_address, "killall marcos_server"])
+                BashExecution("./communicateRP.sh", hw.rp_ip_address, "killall marcos_server")
                 self.action_server.setStatusTip('Connect to marcos server')
                 self.action_server.setToolTip('Connect to marcos server')
                 print("Server disconnected")
             else:
                 try:
-                    subprocess.run([hw.bash_path, "--", "./communicateRP.sh", hw.rp_ip_address, "killall marcos_server"])
+                    BashExecution("./communicateRP.sh", hw.rp_ip_address, "killall marcos_server")
                     time.sleep(1.5)
-                    subprocess.run([hw.bash_path, "--", "./communicateRP.sh", hw.rp_ip_address, "~/marcos_server"])
+                    BashExecution("./communicateRP.sh", hw.rp_ip_address, "~/marcos_server")
                     time.sleep(1.5)
                     self.action_server.setStatusTip('Kill marcos server')
                     self.action_server.setToolTip('Kill marcos server')
@@ -182,8 +184,8 @@ class MarcosController(MarcosToolBar):
         """
         if not self.main.demo:
             try:
-                subprocess.run([hw.bash_path, "--", "./communicateRP.sh", hw.rp_ip_address, "killall marcos_server"])
-                subprocess.run([hw.bash_path, '--', './copy_bitstream.sh', hw.rp_ip_address, 'rp-122'], timeout=10)
+                BashExecution("./communicateRP.sh", hw.rp_ip_address, "killall marcos_server")
+                BashExecution("./copy_bitstream.sh", hw.rp_ip_address, "rp-122", timeout=10)
                 print("READY: MaRCoS updated")
             except subprocess.TimeoutExpired as e:
                 print("ERROR: MaRCoS init timeout")
@@ -326,5 +328,4 @@ class MarcosController(MarcosToolBar):
 
         thread = threading.Thread(target=init_gpa)
         thread.start()
-
 

--- a/marge/utils/__init__.py
+++ b/marge/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers shared across MaRGE modules."""

--- a/marge/utils/bash_execution.py
+++ b/marge/utils/bash_execution.py
@@ -1,9 +1,41 @@
+import os
 import platform
+import shutil
 import subprocess
-from getpass import getuser
 from pathlib import Path
 
 import marge.configs.hw_config as hw
+
+
+def _resolve_windows_bash():
+    """
+    Locate a usable bash executable on Windows.
+
+    Prefer an executable already available on PATH so custom or system-wide Git
+    installations work without extra configuration. If PATH does not contain a
+    bash executable, probe the most common Git for Windows installation
+    directories before failing.
+    """
+    for candidate in ("bash.exe", "bash"):
+        resolved = shutil.which(candidate)
+        if resolved:
+            return resolved
+
+    search_roots = []
+    for env_var in ("LOCALAPPDATA", "ProgramFiles", "ProgramFiles(x86)"):
+        root = os.environ.get(env_var)
+        if root:
+            search_roots.append(Path(root))
+
+    for root in search_roots:
+        for relative in ("Programs/Git/usr/bin/bash.exe", "Programs/Git/bin/bash.exe", "Git/usr/bin/bash.exe", "Git/bin/bash.exe"):
+            candidate = root / relative
+            if candidate.exists():
+                return str(candidate)
+
+    raise FileNotFoundError(
+        "Unable to locate a Windows bash executable. Add Git Bash to PATH or configure hw.bash_override."
+    )
 
 
 def get_bash_launcher():
@@ -20,8 +52,7 @@ def get_bash_launcher():
     if system == "Linux":
         return "gnome-terminal"
     if system == "Windows":
-        username = getuser()
-        return str(Path(rf"C:\Users\{username}\AppData\Local\Programs\Git\usr\bin\bash.exe"))
+        return _resolve_windows_bash()
     if system == "Darwin":
         return str(Path("/Applications/Terminal.app"))
     raise RuntimeError(f"Unsupported operating system: {system}")

--- a/marge/utils/bash_execution.py
+++ b/marge/utils/bash_execution.py
@@ -1,0 +1,52 @@
+import platform
+import subprocess
+from getpass import getuser
+from pathlib import Path
+
+import marge.configs.hw_config as hw
+
+
+def get_bash_launcher():
+    """
+    Resolve the launcher used for bash/script execution.
+
+    A configured hardware override wins. Otherwise we fall back to a small
+    platform-specific default so callers do not have to duplicate this logic.
+    """
+    if getattr(hw, "bash_override", ""):
+        return str(hw.bash_override)
+
+    system = platform.system()
+    if system == "Linux":
+        return "gnome-terminal"
+    if system == "Windows":
+        username = getuser()
+        return str(Path(rf"C:\Users\{username}\AppData\Local\Programs\Git\usr\bin\bash.exe"))
+    if system == "Darwin":
+        return str(Path("/Applications/Terminal.app"))
+    raise RuntimeError(f"Unsupported operating system: {system}")
+
+
+def build_bash_command(script_path, *script_args):
+    """
+    Build the concrete subprocess command for the current platform.
+
+    macOS `.app` bundles cannot be executed directly with `subprocess.run`, so
+    the default Terminal.app launcher is translated to a real shell for these
+    blocking script executions.
+    """
+    launcher = get_bash_launcher()
+    if platform.system() == "Darwin" and launcher.endswith(".app"):
+        return ["/bin/bash", str(script_path), *[str(arg) for arg in script_args]]
+    return [launcher, "--", str(script_path), *[str(arg) for arg in script_args]]
+
+
+def BashExecution(script_path, *script_args, timeout=None, **kwargs):
+    """
+    Execute a shell-accessible script through the configured terminal/bash launcher.
+
+    This keeps launcher resolution and the wrapper command structure in one
+    place so callers do not have to duplicate it.
+    """
+    command = build_bash_command(script_path, *script_args)
+    return subprocess.run(command, timeout=timeout, **kwargs)

--- a/marge/widgets/widget_hw_others.py
+++ b/marge/widgets/widget_hw_others.py
@@ -29,7 +29,11 @@ class OthersWidget(QWidget):
         self.add_input(label="FOVy (cm)", value="20.0", tip="Field of View in the Y direction")
         self.add_input(label="FOVz (cm)", value="20.0", tip="Field of View in the Z direction")
         self.add_input(label="Shimming factor", value="1e-5", tip="Factor used for shimming adjustments")
-        self.add_input(label="Bash path", value="gnome-terminal", tip="Path for executing bash commands")
+        self.add_input(
+            label="Bash override",
+            value="",
+            tip="Optional override for the bash/terminal launcher. Leave empty to use the OS default.",
+        )
         self.add_input(label="Tyger server", value="localhost", tip="Tyger server")
         self.add_input(label="Tyger batch size", value="1000", tip="Tyger batch size. Reduce the value for weaker GPUs")
         self.add_input(label="SNRAware version", value="None", tip="'None', 'Local', 'TEP'")
@@ -83,7 +87,7 @@ class OthersWidget(QWidget):
                   float(self.input_boxes["FOVy (cm)"].text()),
                   float(self.input_boxes["FOVz (cm)"].text())]
         hw.shimming_factor = float(self.input_boxes["Shimming factor"].text())
-        hw.bash_path = self.input_boxes["Bash path"].text()
+        hw.bash_override = self.input_boxes["Bash override"].text().strip()
         hw.ard_sn_interlock = self.input_boxes["Arduino interlock"].text()
         hw.ard_br_interlock = int(self.input_boxes["Arduino interlock baudrate"].text())
         hw.ard_sn_autotuning = self.input_boxes["Arduino autotuning"].text()
@@ -114,6 +118,9 @@ class OthersWidget(QWidget):
                 for row in reader:
                     if len(row) == 2:  # Ensure row has two columns
                         label, value = row
+                        if label == "Bash path":
+                            # Migrate the legacy field name to the new override entry.
+                            label = "Bash override"
                         if label in self.input_boxes:
                             self.input_boxes[label].setText(value)  # Update input box
         except:


### PR DESCRIPTION
Problem was that manual setting up the bash under different users and MacOS was a additional setup process - this fix added a smaller utils bash execution function to resolve os specific bash paths in a single place - the user is able to optional define a override path manually - furthermore the missing Mac os calls for pin the RP are added.

Tested on Win11 and MacOS 26.1, Linux Mint