### PR TITLE
MacOS shell script fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Install MaRGE with pip if you only need to run the GUI and do not plan to modify
 
 * Linux / MacOS
 
-    Note: # On MacOS, the `timeout` command is not available by default, so  `gtimeout` (which can be installed via `Homebrew`) is required. In addition the `marcos_install.sh` cant be used, so the initial hardware setup needs to be performed on a Linux system.
+    Note: # On MacOS, the `timeout` command is not available by default, so  `gtimeout` (which can be installed via `Homebrew: brew install coreutils`) is required. In addition the `marcos_install.sh` cant be used, so the initial hardware setup needs to be performed on a Linux system.
 
   ```bash
   python3 -m venv venv

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ Install MaRGE with pip if you only need to run the GUI and do not plan to modify
 
 1. Go to your project folder.Create and activate a virtual environment:
 
-* Ubuntu
+* Linux / MacOS
+
+    Note: # On MacOS, the `timeout` command is not available by default, so  `gtimeout` (which can be installed via `Homebrew`) is required. In addition the `marcos_install.sh` cant be used, so the initial hardware setup needs to be performed on a Linux system.
+
   ```bash
   python3 -m venv venv
   source venv/bin/activate

--- a/marge/communicateRP.sh
+++ b/marge/communicateRP.sh
@@ -6,5 +6,5 @@ elif command -v gtimeout >/dev/null 2>&1; then
     # Use homebrew to install coreutils: brew install coreutils
     exec gtimeout 2s ssh -o BatchMode=yes -o ConnectTimeout=2 -o ConnectionAttempts=1 "root@$1" "$2"
 else
-    exec ssh -o BatchMode=yes -o ConnectTimeout=2 -o ConnectionAttempts=1 "root@$1" "$2"
+    echo "Error: timeout command not found. Please install coreutils to get the timeout command." >&2
 fi

--- a/marge/communicateRP.sh
+++ b/marge/communicateRP.sh
@@ -1,3 +1,10 @@
 #!/bin/sh
-
-timeout 2s ssh root@$1 $2
+if command -v timeout >/dev/null 2>&1; then
+    exec timeout 2s ssh -o BatchMode=yes -o ConnectTimeout=2 -o ConnectionAttempts=1 "root@$1" "$2"
+elif command -v gtimeout >/dev/null 2>&1; then
+    # On MacOS, the timeout command is called gtimeout and is provided by coreutils. If it's available, use it instead of timeout.
+    # Use homebrew to install coreutils: brew install coreutils
+    exec gtimeout 2s ssh -o BatchMode=yes -o ConnectTimeout=2 -o ConnectionAttempts=1 "root@$1" "$2"
+else
+    exec ssh -o BatchMode=yes -o ConnectTimeout=2 -o ConnectionAttempts=1 "root@$1" "$2"
+fi

--- a/startRP.sh
+++ b/startRP.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 
-../MaRGE/copy_bitstream.sh $1 $2
-timeout 2s ssh root@$1 "~/marcos_server &"
+../MaRGE/copy_bitstream.sh "$1" "$2"
+
+if command -v timeout >/dev/null 2>&1; then
+    exec timeout 2s ssh -o BatchMode=yes -o ConnectTimeout=2 -o ConnectionAttempts=1 "root@$1" "~/marcos_server &"
+elif command -v gtimeout >/dev/null 2>&1; then
+    exec gtimeout 2s ssh -o BatchMode=yes -o ConnectTimeout=2 -o ConnectionAttempts=1 "root@$1" "~/marcos_server &"
+else
+    exec ssh -o BatchMode=yes -o ConnectTimeout=2 -o ConnectionAttempts=1 "root@$1" "~/marcos_server &"
+fi

--- a/startRP.sh
+++ b/startRP.sh
@@ -7,5 +7,5 @@ if command -v timeout >/dev/null 2>&1; then
 elif command -v gtimeout >/dev/null 2>&1; then
     exec gtimeout 2s ssh -o BatchMode=yes -o ConnectTimeout=2 -o ConnectionAttempts=1 "root@$1" "~/marcos_server &"
 else
-    exec ssh -o BatchMode=yes -o ConnectTimeout=2 -o ConnectionAttempts=1 "root@$1" "~/marcos_server &"
+    echo "Error: timeout command not found. Please install coreutils to get the timeout command." >&2
 fi


### PR DESCRIPTION
For full MacOS support - the last missing thing is the used timeout command in the shell scripts. On Mac only gtimeout is available - the communication and start .sh scripts no check for that.
An additional note is added to the README