### PR TITLE
Recursive Sequence Loading

### DIFF
--- a/marge/controller/controller_sequence_list.py
+++ b/marge/controller/controller_sequence_list.py
@@ -43,6 +43,10 @@ class SequenceListController(SequenceListWidget):
         Returns:
             str: The name of the current sequence.
         """
+        # Read the internal key stored in the combo box item, not the visible label.
+        seq_name = self.currentData()
+        if seq_name is not None:
+            return seq_name
         return self.currentText()
 
     def updateSequence(self):

--- a/marge/seq/README.md
+++ b/marge/seq/README.md
@@ -1,0 +1,46 @@
+# Sequence Loading
+
+`marge/seq` contains sequence modules that can be shown in the MaRGE GUI.
+
+## How It Works
+
+- MaRGE scans `marge/seq` recursively.
+- Every `.py` file is checked except `__init__.py` and `sequences.py`.
+- Files in subfolders are loaded directly from their path, so subfolders do not need an `__init__.py`.
+- A file is only loaded as a sequence module if it defines a class inheriting `MRIBLANKSEQ`, for example `class MySeq(blankSeq.MRIBLANKSEQ):`.
+- Imported classes are ignored; only classes defined in the scanned module are considered.
+- A sequence is added only if its class instance sets `mapVals['toMaRGE']` to `True`.
+- Helper files used to split complex logic are ignored unless they define a `MRIBLANKSEQ` subclass.
+
+## Naming
+
+- The internal lookup key is `mapVals['seqName']`.
+- Sequences found in subfolders are shown in the GUI with a folder-prefixed label such as `custom/MySequence`.
+- Root-level sequences are shown with just their `seqName`.
+
+## Duplicates
+
+- `seqName` must be unique across all loaded sequences.
+- If two sequences use the same `seqName`, the first one found after path sorting is kept.
+- Later duplicates are skipped and a warning is printed during loading.
+
+## Example
+
+If you add:
+
+```text
+marge/seq/custom/my_sequence.py
+```
+
+and that file defines a sequence with:
+
+```python
+self.addParameter(key='seqName', val='MySequence')
+self.addParameter(key='toMaRGE', val=True)
+```
+
+then it will appear in the GUI as:
+
+```text
+custom/MySequence
+```

--- a/marge/seq/sequences.py
+++ b/marge/seq/sequences.py
@@ -4,9 +4,12 @@ Created on Thu June 2 2022
 @email: josalggui@i3m.upv.es
 @Summary: All sequences on the GUI must be here
 """
+import ast
 import inspect
 import os
-import importlib
+import importlib.util
+
+from marge.seq.mriBlankSeq import MRIBLANKSEQ
 
 """
 Definition of default sequences
@@ -17,24 +20,66 @@ Definition of default sequences
 # self.addParameter(string='toMaRGE', val=True)
 # This file should not be modified anymore.
 
+
+def _base_name(node):
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _base_name(node.value)
+        if prefix:
+            return f"{prefix}.{node.attr}"
+        return node.attr
+    return None
+
+
+def _contains_sequence_class_candidate(py_file):
+    try:
+        with open(py_file, "r", encoding="utf-8") as source:
+            tree = ast.parse(source.read(), filename=py_file)
+    except Exception:
+        return False
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for base in node.bases:
+            base_name = _base_name(base)
+            if base_name and base_name.split(".")[-1] == "MRIBLANKSEQ":
+                return True
+    return False
+
 def instantiate_sequences():
     # Get the absolute path to this folder (marge/seq)
     folder = os.path.dirname(__file__)
 
-    # Dictionary to store class sequences
+    # Store the sequence instances and the names shown in the GUI.
     defaultsequences = {}
+    sequence_display_names = {}
 
-    # List all .py files in the folder, except __init__.py
-    py_files = [f for f in os.listdir(folder) if f.endswith('.py') and f != '__init__.py']
+    # Search recursively so custom sequences inside subfolders are discovered too.
+    py_files = []
+    for root, _, files in os.walk(folder):
+        for file in files:
+            if file.endswith('.py') and file not in {'__init__.py', 'sequences.py'}:
+                py_file = os.path.join(root, file)
+                if _contains_sequence_class_candidate(py_file):
+                    py_files.append(py_file)
+    py_files.sort()
 
     # Populate defaultsequences
-    for file in py_files:
-        # Remove the .py extension to get the module name
-        module_name = file[:-3]
+    for py_file in py_files:
+        rel_path = os.path.relpath(py_file, folder)
+        rel_module_name = rel_path[:-3].replace(os.sep, '.')
+        folder_prefix = os.path.dirname(rel_path).replace(os.sep, '/')
+        module_name = f"marge.seq.{rel_module_name}"
 
         try:
-            # Dynamically import the module using full path
-            module = importlib.import_module(f"marge.seq.{module_name}")
+            # Load modules from file paths so subfolders do not need to be Python packages.
+            spec = importlib.util.spec_from_file_location(module_name, py_file)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Unable to create import spec for {py_file}")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
 
             # Find all classes in the module
             classes = inspect.getmembers(module, inspect.isclass)
@@ -42,17 +87,35 @@ def instantiate_sequences():
             # Add to defaultsequences only if toMaRGE is True
             for class_name, class_ in classes:
                 try:
-                    if class_().mapVals['toMaRGE']:
-                        defaultsequences[class_().mapVals['seqName']] = class_()
-                        print(f"{class_().mapVals['seqName']} added to MaRGE")
+                    # Only classes defined in the module and inheriting MRIBLANKSEQ are sequences.
+                    if (
+                        class_.__module__ != module.__name__
+                        or class_ is MRIBLANKSEQ
+                        or not issubclass(class_, MRIBLANKSEQ)
+                    ):
+                        continue
+
+                    sequence = class_()
+                    if sequence.mapVals['toMaRGE']:
+                        seq_name = sequence.mapVals['seqName']
+                        if seq_name in defaultsequences:
+                            print(f"WARNING: Duplicate sequence name '{seq_name}' found in {rel_path}.")
+                            continue
+
+                        defaultsequences[seq_name] = sequence
+                        if folder_prefix:
+                            sequence_display_names[seq_name] = f"{folder_prefix}/{seq_name}"
+                        else:
+                            sequence_display_names[seq_name] = seq_name
+                        print(f"{sequence_display_names[seq_name]} added to MaRGE")
                 except:
                     pass
         except Exception as e:
             print(f"Error importing module {module_name}: {e}")
 
-    return defaultsequences
+    return defaultsequences, sequence_display_names
 
-defaultsequences = instantiate_sequences()
+defaultsequences, sequence_display_names = instantiate_sequences()
 
 # Note for the users: Now the sequences are added automatically to the defaultsequences dictionary.
 # To do that, the user should include the parameter 'toMaRGE' as True in the sequence using:

--- a/marge/widgets/widget_sequence_list.py
+++ b/marge/widgets/widget_sequence_list.py
@@ -4,7 +4,7 @@
 @affiliation:MRILab, i3M, CSIC, Valencia, Spain
 """
 from PyQt5.QtWidgets import QComboBox, QSizePolicy
-from marge.seq.sequences import defaultsequences
+from marge.seq.sequences import defaultsequences, sequence_display_names
 
 
 class SequenceListWidget(QComboBox):
@@ -13,8 +13,13 @@ class SequenceListWidget(QComboBox):
         super(SequenceListWidget, self).__init__(*args, **kwargs)
         self.main = parent
 
-        # Add sequences to sequences list
-        self.addItems(sorted(list(defaultsequences.keys())))
+        # Keep root sequences first and append folder-prefixed ones afterwards.
+        ordered_keys = sorted(
+            defaultsequences.keys(),
+            key=lambda key: ("/" in sequence_display_names.get(key, key), sequence_display_names.get(key, key).lower())
+        )
+        for key in ordered_keys:
+            self.addItem(sequence_display_names.get(key, key), key)
 
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
         self.setMaximumWidth(400)


### PR DESCRIPTION
Hi @josalggui, 
I closed the combined #36 PR in order to rework and move the recursive seq loading into an individual PR.
The implemented logic is still the same it allows for additional load sequences dynamically from folders located inside the the seq folder.
Tested with a clean marge install and is fully backward compatible if a flat seq folder is used as structured in the repo.
We are using it a lot in our setup and this PR bring the feature to the latest .4b version of marge :)


Cheers,
Marcel