### PR TITLE
Fixed Call Marge as Module and CLI

### DIFF
--- a/marge/__main__.py
+++ b/marge/__main__.py
@@ -1,0 +1,7 @@
+"""Command-line entry point for MaRGE."""
+
+from marge.main import main
+
+
+if __name__ == "__main__":
+    main()

--- a/marge/main.py
+++ b/marge/main.py
@@ -5,6 +5,7 @@ import os
 import sys
 from PyQt5.QtWidgets import QApplication
 
+
 def MaRGE():
     """
     Entry point for the MaRGE graphical user interface.
@@ -40,5 +41,11 @@ def MaRGE():
     gui.show()
     sys.exit(app.exec_())
 
-if __name__ == "__main__":
+
+def main():
+    """Console-script entry point."""
     MaRGE()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "MaRCoS Graphical Environment (MaRGE)"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -44,10 +44,11 @@ dependencies = [
 ]
 
 [project.scripts]
-marge-mri = "marge.main:MaRGE"
+marge-mri = "marge.__main__:main"
 
-[tool.hatch.build.targets.wheel]
-packages = ["src/marge"]
-
-[tools.setuptools]
+[tool.setuptools]
 include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["marge*"]

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,8 @@ setup(
     version="1.0.0b4",
     author="José Miguel Algarín",
     author_email="josalggui@i3m.upv.es",
-    packages=find_packages(),
+    packages=find_packages(include=["marge", "marge.*"]),
+    include_package_data=True,
     install_requires=[],
     description="MaRCoS Graphical Environment (MaRGE)",
-    entry_points={
-        "console_scripts": [
-            "marge-mri=marge.main:MaRGE",
-        ],
-    },
 )
-

--- a/uv.lock
+++ b/uv.lock
@@ -536,7 +536,7 @@ wheels = [
 
 [[package]]
 name = "marge-mri"
-version = "1.0.0b3"
+version = "1.0.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "bm4d" },


### PR DESCRIPTION
Hi @josalggui, 
due to the rework the marge module and folder structure it wasn't possible anymore to use the in the readme described


$ marge-mri 

or

$ python -m marge 

The commit in this PR resolves it for the new structure and the commands from the README working fine agin :)
I closed the old #38 PR which fixed the same for the old v0.9 structure.
Cheers,
Marcel